### PR TITLE
rename configurator's onDraw method to onDrawListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pdfView.fromAsset(pdfName)
     .defaultPage(1)
     .showMinimap(false)
     .enableSwipe(true)
-    .onDraw(onDrawListener)
+    .onDrawListener(onDrawListener)
     .onLoad(onLoadCompleteListener)
     .onPageChange(onPageChangeListener)
     .load();

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
@@ -946,7 +946,7 @@ public class PDFView extends SurfaceView {
             return this;
         }
 
-        public Configurator onDraw(OnDrawListener onDrawListener) {
+        public Configurator onDrawListener(OnDrawListener onDrawListener) {
             this.onDrawListener = onDrawListener;
             return this;
         }


### PR DESCRIPTION
hi, joan,

Eclipse ADT with latest SDK will mark an PDFView's onDraw call which set on draw listener an error if we use old name "onDraw". So I change the effected name.

Signed-off-by: wenpincui wenpincui224@gmail.com
