### PR TITLE
Add compatibility for API 10 Gingerbread

### DIFF
--- a/android-pdfview/build.gradle
+++ b/android-pdfview/build.gradle
@@ -13,3 +13,7 @@ android {
         }
     }
 }
+
+dependencies {
+    compile 'com.nineoldandroids:library:2.4.0'
+}

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/AnimationManager.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/AnimationManager.java
@@ -18,10 +18,10 @@
  */
 package com.joanzapata.pdfview;
 
-import android.animation.Animator;
-import android.animation.Animator.AnimatorListener;
-import android.animation.ValueAnimator;
-import android.animation.ValueAnimator.AnimatorUpdateListener;
+import com.nineoldandroids.animation.Animator;
+import com.nineoldandroids.animation.Animator.AnimatorListener;
+import com.nineoldandroids.animation.ValueAnimator;
+import com.nineoldandroids.animation.ValueAnimator.AnimatorUpdateListener;
 import android.graphics.PointF;
 import android.view.animation.DecelerateInterpolator;
 

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
@@ -18,11 +18,13 @@
  */
 package com.joanzapata.pdfview;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.*;
 import android.graphics.Paint.Style;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.SurfaceView;
 import com.joanzapata.pdfview.exception.FileNotFoundException;
@@ -216,6 +218,7 @@ public class PDFView extends SurfaceView {
         load(uri, listener, null);
     }
 
+    @TargetApi(11)
     private void load(Uri uri, OnLoadCompleteListener onLoadCompleteListener, int[] userPages) {
 
         if (!recycled) {
@@ -233,7 +236,12 @@ public class PDFView extends SurfaceView {
 
         // Start decoding document
         decodingAsyncTask = new DecodingAsyncTask(uri, this);
-        decodingAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            decodingAsyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        }
+        else {
+            decodingAsyncTask.execute();
+        }
 
         renderingAsyncTask = new RenderingAsyncTask(this);
         renderingAsyncTask.execute();


### PR DESCRIPTION
Adds compatibility for this library to work on phones running API 10 and possibly below (only tested on API 10). The changes are due to animation changes and THREAD_POOL_EXECUTOR being added in API 11; this caused crashes to occur in phones below that version. These changes add NineOldAndroids as a dependency library to account for the animation changes, and use a standard async execute below API 11.