### PR TITLE
Added maskColor and maskAlpha to PDFView builder

### DIFF
--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
@@ -195,9 +195,6 @@ public class PDFView extends SurfaceView {
         paint = new Paint();
         debugPaint = new Paint();
         debugPaint.setStyle(Style.STROKE);
-        maskPaint = new Paint();
-        maskPaint.setColor(Color.BLACK);
-        maskPaint.setAlpha(Constants.MASK_ALPHA);
         paintMinimapBack = new Paint();
         paintMinimapBack.setStyle(Style.FILL);
         paintMinimapBack.setColor(Color.BLACK);
@@ -998,6 +995,10 @@ public class PDFView extends SurfaceView {
         
         private boolean swipeVertical = false;
 
+        private int maskColor = Color.BLACK;
+
+        private int maskAlpha = Constants.MASK_ALPHA;
+
         private Configurator(Uri uri) {
             this.uri = uri;
         }
@@ -1037,6 +1038,17 @@ public class PDFView extends SurfaceView {
             return this;
         }
 
+        /**
+         * @param maskColor - mask color (default Color.BLACK)
+         * @param maskAlpha - alpha value in [0,255] (default 20)
+         * @return
+         */
+        public Configurator mask(int maskColor, int maskAlpha) {
+            this.maskColor = maskColor;
+            this.maskAlpha = maskAlpha;
+            return this;
+        }
+
         public void load() {
             PDFView.this.recycle();
             PDFView.this.setOnDrawListener(onDrawListener);
@@ -1046,6 +1058,9 @@ public class PDFView extends SurfaceView {
             PDFView.this.setUserWantsMinimap(showMinimap);
             PDFView.this.setSwipeVertical(swipeVertical);
             PDFView.this.dragPinchManager.setSwipeVertical(swipeVertical);
+            PDFView.this.maskPaint = new Paint();
+            PDFView.this.maskPaint.setColor(maskColor);
+            PDFView.this.maskPaint.setAlpha(maskAlpha);
             if (pageNumbers != null) {
                 PDFView.this.load(uri, onLoadCompleteListener, pageNumbers);
             } else {


### PR DESCRIPTION
Now it is possible to change mask color and alpha by calling (for example):

.mask(int color, int alpha)

on the PDFView builder.

As a special case we can hide the prev/next pages previews by calling:

.mask(Color.WHITE, 255)