### PR TITLE
Patch 3

### DIFF
--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/DragPinchManager.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/DragPinchManager.java
@@ -59,9 +59,9 @@ class DragPinchManager implements OnDragListener, OnPinchListener, OnDoubleTapLi
     }
     
     public void enableDoubletap(boolean enableDoubletap){
-        if(enableDoubletap){
+        if (enableDoubletap) {
             dragPinchListener.setOnDoubleTapListener(this);
-        }else{
+        } else {
             dragPinchListener.setOnDoubleTapListener(null);
         }
     }

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/DragPinchManager.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/DragPinchManager.java
@@ -57,7 +57,15 @@ class DragPinchManager implements OnDragListener, OnPinchListener, OnDoubleTapLi
         dragPinchListener.setOnDoubleTapListener(this);
         pdfView.setOnTouchListener(dragPinchListener);
     }
-
+    
+    public void enableDoubletap(boolean enableDoubletap){
+        if(enableDoubletap){
+            dragPinchListener.setOnDoubleTapListener(this);
+        }else{
+            dragPinchListener.setOnDoubleTapListener(null);
+        }
+    }
+    
     @Override
     public void onPinch(float dr, PointF pivot) {
         float wantedZoom = pdfView.getZoom() * dr;

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
@@ -286,6 +286,7 @@ public class PDFView extends SurfaceView {
     public void enableDoubletap(boolean enableDoubletap){
         this.dragPinchManager.enableDoubletap(enableDoubletap);
     }
+    
     private void setOnPageChangeListener(OnPageChangeListener onPageChangeListener) {
         this.onPageChangeListener = onPageChangeListener;
     }

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
@@ -282,7 +282,10 @@ public class PDFView extends SurfaceView {
     public void enableSwipe(boolean enableSwipe) {
         dragPinchManager.setSwipeEnabled(enableSwipe);
     }
-
+    
+    public void enableDoubletap(boolean enableDoubletap){
+        this.dragPinchManager.enableDoubletap(enableDoubletap);
+    }
     private void setOnPageChangeListener(OnPageChangeListener onPageChangeListener) {
         this.onPageChangeListener = onPageChangeListener;
     }
@@ -983,6 +986,8 @@ public class PDFView extends SurfaceView {
 
         private boolean enableSwipe = true;
 
+	private boolean enableDoubletap = true ;
+
         private OnDrawListener onDrawListener;
 
         private OnLoadCompleteListener onLoadCompleteListener;
@@ -1012,7 +1017,12 @@ public class PDFView extends SurfaceView {
             this.enableSwipe = enableSwipe;
             return this;
         }
-
+        
+	public Configurator enableDoubletap(boolean enableDoubletap){
+            this.enableDoubletap = enableDoubletap ;
+            return this ;
+        }
+        
         public Configurator onDraw(OnDrawListener onDrawListener) {
             this.onDrawListener = onDrawListener;
             return this;
@@ -1054,6 +1064,7 @@ public class PDFView extends SurfaceView {
             PDFView.this.setOnDrawListener(onDrawListener);
             PDFView.this.setOnPageChangeListener(onPageChangeListener);
             PDFView.this.enableSwipe(enableSwipe);
+            PDFView.this.enableDoubletap(enableDoubletap);
             PDFView.this.setDefaultPage(defaultPage);
             PDFView.this.setUserWantsMinimap(showMinimap);
             PDFView.this.setSwipeVertical(swipeVertical);

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/util/DragPinchListener.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/util/DragPinchListener.java
@@ -161,7 +161,7 @@ public class DragPinchListener implements OnTouchListener {
                 if (isClick(event, lastDownX, lastDownY, event.getX(), event.getY())) {
                     long time = System.currentTimeMillis();
                     handlerClick.removeCallbacks(runnableClick);
-                    if(onDoubleTapListener != null) {
+                    if (onDoubleTapListener != null) {
                         if (time - lastClickTime < MAX_DOUBLE_CLICK_TIME) {
                             onDoubleTapListener.onDoubleTap(event.getX(), event.getY());
                             lastClickTime = 0;
@@ -169,7 +169,7 @@ public class DragPinchListener implements OnTouchListener {
                             lastClickTime = System.currentTimeMillis();
                             handlerClick.postDelayed(runnableClick, MAX_CLICK_TIME);
                         }
-                    }else{
+                    } else {
                         handlerClick.postDelayed(runnableClick,0);
                     }
                 }

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/util/DragPinchListener.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/util/DragPinchListener.java
@@ -159,16 +159,18 @@ public class DragPinchListener implements OnTouchListener {
 
                 // Treat clicks
                 if (isClick(event, lastDownX, lastDownY, event.getX(), event.getY())) {
-                    handlerClick.removeCallbacks(runnableClick);
                     long time = System.currentTimeMillis();
-                    if (time - lastClickTime < MAX_DOUBLE_CLICK_TIME) {
-                        if (onDoubleTapListener != null) {
+                    handlerClick.removeCallbacks(runnableClick);
+                    if(onDoubleTapListener != null) {
+                        if (time - lastClickTime < MAX_DOUBLE_CLICK_TIME) {
                             onDoubleTapListener.onDoubleTap(event.getX(), event.getY());
+                            lastClickTime = 0;
+                        } else {
+                            lastClickTime = System.currentTimeMillis();
+                            handlerClick.postDelayed(runnableClick, MAX_CLICK_TIME);
                         }
-                        lastClickTime = 0;
-                    } else {
-                        lastClickTime = System.currentTimeMillis();
-                        handlerClick.postDelayed(runnableClick,MAX_CLICK_TIME);
+                    }else{
+                        handlerClick.postDelayed(runnableClick,0);
                     }
                 }
                 break;


### PR DESCRIPTION
This way, we can disable doubletap if we want, and trigger immediatly the onClick event. For retro-compatibility, the DoubleTap event is active by default