### PR TITLE
Fix NullPointerException in Rendering task

### DIFF
--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/RenderingAsyncTask.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/RenderingAsyncTask.java
@@ -58,14 +58,22 @@ class RenderingAsyncTask extends AsyncTask<Void, PagePart, Void> {
         while (!isCancelled()) {
 
             // Proceed all tasks
-            while (!renderingTasks.isEmpty()) {
-                RenderingTask task = renderingTasks.get(0);
-                PagePart part = proceed(task);
-
-                if (renderingTasks.remove(task)) {
-                    publishProgress(part);
-                } else {
-                    part.getRenderedBitmap().recycle();
+            // Use an iterator, so make sure we get something 
+            // previous use renderingTasks.get(0) could return null
+            ListIterator<RenderingTask> renderingTaksIt = renderingTasks.listIterator();
+            while (renderingTaksIt.hasNext()) {
+                RenderingTask task = renderingTaksIt.next();
+                // make sure we got a task to process
+                if(task != null) {
+                    PagePart part = proceed(task);
+                    // make sure proceed return something valid
+                    if(part != null) {
+                        if (renderingTaksIt.remove(task)) {
+                            publishProgress(part);
+                        } else {
+                            part.getRenderedBitmap().recycle();
+                        }
+                    }
                 }
             }
 
@@ -96,19 +104,22 @@ class RenderingAsyncTask extends AsyncTask<Void, PagePart, Void> {
     }
 
     private PagePart proceed(RenderingTask renderingTask) {
-        this.decodeService = pdfView.getDecodeService();
-        CodecPage page = decodeService.getPage(renderingTask.page);
-        Bitmap render;
+        // Maybe we should check here that renderingTask is not null
+        PagePart part = null;
+        if(renderingTask != null) {
+            this.decodeService = pdfView.getDecodeService();
+            CodecPage page = decodeService.getPage(renderingTask.page); // the isse was here, renderingTask was null
+            Bitmap render;
 
-        synchronized (decodeService.getClass()) {
-            render = page.renderBitmap(Math.round(renderingTask.width), Math.round(renderingTask.height), renderingTask.bounds);
-        }
+            synchronized (decodeService.getClass()) {
+                render = page.renderBitmap(Math.round(renderingTask.width), Math.round(renderingTask.height), renderingTask.bounds);
+            }
 
-        PagePart part = new PagePart(renderingTask.userPage, renderingTask.page, render, //
-                renderingTask.width, renderingTask.height, //
-                renderingTask.bounds, renderingTask.thumbnail, //
-                renderingTask.cacheOrder);
-
+            PagePart part = new PagePart(renderingTask.userPage, renderingTask.page, render, //
+                    renderingTask.width, renderingTask.height, //
+                    renderingTask.bounds, renderingTask.thumbnail, //
+                    renderingTask.cacheOrder);
+        } 
         return part;
     }
 


### PR DESCRIPTION
Hi,
here is a patch to prevent the library to crash when renderingTask is null.
I also replace "isEmpty()" and "get(0)", by an iterator.
I added some test != null to prevent any crash.

Here is the Exception: java.lang.NullPointerException: Attempt to read from field 'int com.joanzapata.pdfview.e$a.d' on a null object reference

Thank you
Cedric

PS: can you please keep up to date the maven repo so we can get the latest version through gradle ? thanks a lot

full stack below :

java.lang.RuntimeException: An error occured while executing doInBackground()
       at android.os.AsyncTask$3.done(AsyncTask.java:304)
       at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:355)
       at java.util.concurrent.FutureTask.setException(FutureTask.java:222)
       at java.util.concurrent.FutureTask.run(FutureTask.java:242)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
       at java.lang.Thread.run(Thread.java:818)
Caused by: java.lang.NullPointerException: Attempt to read from field 'int com.joanzapata.pdfview.e$a.d' on a null object reference
       at com.joanzapata.pdfview.RenderingAsyncTask.proceed(RenderingAsyncTask.java:100)
       at com.joanzapata.pdfview.RenderingAsyncTask.doInBackground(RenderingAsyncTask.java:33)
       at android.os.AsyncTask$2.call(AsyncTask.java:292)
       at java.util.concurrent.FutureTask.run(FutureTask.java:237)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
       at java.lang.Thread.run(Thread.java:818)