### PR TITLE
Feature/zoom scroll

### DIFF
--- a/android-pdfview-sample/build.gradle
+++ b/android-pdfview-sample/build.gradle
@@ -4,7 +4,7 @@ description = 'android-pdfview-sample'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8

--- a/android-pdfview/build.gradle
+++ b/android-pdfview/build.gradle
@@ -4,7 +4,7 @@ description = 'android-pdfview'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion '19.0.3'
+    buildToolsVersion '19.1.0'
 
     sourceSets {
         main {

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/util/Constants.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/util/Constants.java
@@ -64,7 +64,9 @@ public interface Constants {
          */
         static final int QUICK_MOVE_THRESHOLD_TIME = 250, //
 
-        QUICK_MOVE_THRESHOLD_DISTANCE = 50;
+        QUICK_MOVE_THRESHOLD_DISTANCE = 50,
+
+        ZOOM_MOVE_THRESHOLD_DISTANCE = 50;
 
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,25 +1,6 @@
-#
-# Copyright 2014 Joan Zapata
-#
-# This file is part of Android-pdfview.
-#
-# Android-pdfview is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Android-pdfview is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Android-pdfview.  If not, see <http://www.gnu.org/licenses/>.
-#
-
-#Fri May 02 16:31:46 BST 2014
+#Fri Oct 30 14:29:41 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip


### PR DESCRIPTION
When a user zooms in a page, and swipes to the end of it, then they cannot scroll to the next page.
This PR changes this by comparing the last known current X or Y Offset (depending on vertical swiping)  and then shows the next/previous page. When this happens the zoom is reset, as it seems most apps with similar functionality, do this.

Unfortunately, I had to change the build.grade sdk versions, as Android Studio complained that the build tools version is too low.

Also I saw that there are some API Calls that require API 11, however the min is set to 8