### PR TITLE
Feature/Set_Cache_Size

### DIFF
--- a/android-pdfview-sample/build.gradle
+++ b/android-pdfview-sample/build.gradle
@@ -4,7 +4,7 @@ description = 'android-pdfview-sample'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8

--- a/android-pdfview/build.gradle
+++ b/android-pdfview/build.gradle
@@ -4,7 +4,7 @@ description = 'android-pdfview'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion '19.0.3'
+    buildToolsVersion '19.1.0'
 
     sourceSets {
         main {

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/PDFView.java
@@ -39,7 +39,7 @@ import org.vudroid.core.DecodeService;
 import java.io.File;
 import java.io.IOException;
 
-import static com.joanzapata.pdfview.util.Constants.Cache.CACHE_SIZE;
+import static com.joanzapata.pdfview.util.Constants.Cache.DEFAULT_CACHE_SIZE;
 
 /**
  * @author Joan Zapata
@@ -180,7 +180,7 @@ public class PDFView extends SurfaceView {
     private int defaultPage = 0;
 
     private boolean userWantsMinimap = false;
-    
+
     /** True if should scroll through pages vertically instead of horizontally */
     private boolean swipeVertical = false;
 
@@ -294,6 +294,11 @@ public class PDFView extends SurfaceView {
     private void setOnDrawListener(OnDrawListener onDrawListener) {
         this.onDrawListener = onDrawListener;
     }
+
+    private void setCacheSize(int cacheSize) {
+        this.cacheManager.setCacheSize(cacheSize);
+    }
+
 
     public void recycle() {
 
@@ -489,10 +494,11 @@ public class PDFView extends SurfaceView {
         // Loop through the pages like [...][4][2][0][1][3][...]
         // loading as many parts as it can.
         int parts = 0;
-        for (int i = 0; i <= Constants.LOADED_SIZE / 2 && parts < CACHE_SIZE; i++) {
-            parts += loadPage(index + i, CACHE_SIZE - parts);
-            if (i != 0 && parts < CACHE_SIZE) {
-                parts += loadPage(index - i, CACHE_SIZE - parts);
+        int cacheSize = this.cacheManager.getCacheSize();
+        for (int i = 0; i <= Constants.LOADED_SIZE / 2 && parts < cacheSize; i++) {
+            parts += loadPage(index + i, cacheSize - parts);
+            if (i != 0 && parts < cacheSize) {
+                parts += loadPage(index - i, cacheSize - parts);
             }
         }
 
@@ -987,7 +993,7 @@ public class PDFView extends SurfaceView {
 
         private boolean enableSwipe = true;
 
-	private boolean enableDoubletap = true ;
+	    private boolean enableDoubletap = true ;
 
         private OnDrawListener onDrawListener;
 
@@ -1005,6 +1011,8 @@ public class PDFView extends SurfaceView {
 
         private int maskAlpha = Constants.MASK_ALPHA;
 
+        private int cacheSize = DEFAULT_CACHE_SIZE;
+
         private Configurator(Uri uri) {
             this.uri = uri;
         }
@@ -1019,7 +1027,7 @@ public class PDFView extends SurfaceView {
             return this;
         }
         
-	public Configurator enableDoubletap(boolean enableDoubletap){
+	    public Configurator enableDoubletap(boolean enableDoubletap){
             this.enableDoubletap = enableDoubletap ;
             return this ;
         }
@@ -1060,8 +1068,20 @@ public class PDFView extends SurfaceView {
             return this;
         }
 
+        /**
+         * Sets the size of the loaded bitmaps kept into memory.
+         * The default is Math.pow(Constants.GRID_SIZE, 2d)
+         * @param cacheSize the new size of the cache
+         * @return the configurator to continue setting up.
+         */
+        public Configurator setCacheSize(int cacheSize) {
+            this.cacheSize = cacheSize;
+            return this;
+        }
+
         public void load() {
             PDFView.this.recycle();
+            PDFView.this.setCacheSize(cacheSize);
             PDFView.this.setOnDrawListener(onDrawListener);
             PDFView.this.setOnPageChangeListener(onPageChangeListener);
             PDFView.this.enableSwipe(enableSwipe);

--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/util/Constants.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/util/Constants.java
@@ -47,7 +47,7 @@ public interface Constants {
     public interface Cache {
 
         /** The size of the cache (number of bitmaps kept) */
-        static final int CACHE_SIZE = (int) Math.pow(GRID_SIZE, 2d);
+        static final int DEFAULT_CACHE_SIZE = (int) Math.pow(GRID_SIZE, 2d);
 
         static final int THUMBNAILS_CACHE_SIZE = 4;
     }

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,25 +1,6 @@
-#
-# Copyright 2014 Joan Zapata
-#
-# This file is part of Android-pdfview.
-#
-# Android-pdfview is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Android-pdfview is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Android-pdfview.  If not, see <http://www.gnu.org/licenses/>.
-#
-
-#Fri May 02 16:31:46 BST 2014
+#Fri Oct 30 14:29:41 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip


### PR DESCRIPTION
Currently the default cache size is fixed as it is determined based on the static grid size. This has the unpleasant effect that only parts of the page get rendered on high resolution (and/or large) screens.

This PR includes a setCacheSize method in the configurator and adjusts the cache size accordingly.

I wasn't sure if I should do this completely transparent to the developer, so I decided to give them the opportunity to decide the size of the cache as they want.

Once again, I had to include a second commit with the build.gradle fixes. :grimacing: 